### PR TITLE
Install npm on Ubuntu when not using PPA

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -91,7 +91,7 @@ class nodejs(
     require => Anchor['nodejs::repo']
   }
 
-  if $::operatingsystem != 'Ubuntu' {
+  if ! ($manage_repo and $::operatingsystem == 'Ubuntu') {
     # The PPA we are using on Ubuntu includes NPM in the nodejs package, hence
     # we must not install it separately
     package { 'npm':


### PR DESCRIPTION
On Ubuntu, if we're not using the PPA, the npm package does need
to be explicitly installed. Modify the boolean logic around the
trap to only skip installing it on Ubuntu if we are, in fact,
also managing the PPA.