### PR TITLE
Deploy from custom registry

### DIFF
--- a/lib/puppet/provider/package/npm.rb
+++ b/lib/puppet/provider/package/npm.rb
@@ -70,10 +70,16 @@ Puppet::Type.type(:package).provide :npm, :parent => Puppet::Provider::Package d
       package = "#{resource[:name]}@#{resource[:ensure]}"
     end
 
+    extraopts = nil
+
     if resource[:source]
       npm('install', '--global', resource[:source])
     else
-      npm('install', '--global', package)
+      if extraopts.nil?
+        npm('install', '--global', package)
+      else
+        npm('install', '--global', extraopts, package)
+      end
     end
   end
 

--- a/lib/puppet/provider/package/npm.rb
+++ b/lib/puppet/provider/package/npm.rb
@@ -3,7 +3,7 @@ require 'puppet/provider/package'
 Puppet::Type.type(:package).provide :npm, :parent => Puppet::Provider::Package do
   desc "npm is package management for node.js. This provider only handles global packages."
 
-  has_feature :versionable
+  has_feature :versionable, :install_options
 
   if Puppet::Util::Package.versioncmp(Puppet.version, '3.0') >= 0
     has_command(:npm, 'npm') do

--- a/lib/puppet/provider/package/npm.rb
+++ b/lib/puppet/provider/package/npm.rb
@@ -70,12 +70,12 @@ Puppet::Type.type(:package).provide :npm, :parent => Puppet::Provider::Package d
       package = "#{resource[:name]}@#{resource[:ensure]}"
     end
 
-    extraopts = nil
+    extraopts = []
 
     if resource[:install_options]
       resource[:install_options].collect do |k,v|
         if k == 'registry'
-          extraopts = "--registry #{v}"
+          extraopts += [ "--registry" , "#{v}" ]
         end
       end
     end
@@ -83,7 +83,7 @@ Puppet::Type.type(:package).provide :npm, :parent => Puppet::Provider::Package d
     if resource[:source]
       npm('install', '--global', resource[:source])
     else
-      if extraopts.nil?
+      if extraopts.empty?
         npm('install', '--global', package)
       else
         npm('install', '--global', extraopts, package)

--- a/lib/puppet/provider/package/npm.rb
+++ b/lib/puppet/provider/package/npm.rb
@@ -72,11 +72,9 @@ Puppet::Type.type(:package).provide :npm, :parent => Puppet::Provider::Package d
 
     extraopts = []
 
-    if resource[:install_options]
-      resource[:install_options].collect do |k,v|
-        if k == 'registry'
-          extraopts += [ "--registry" , "#{v}" ]
-        end
+    extraopts += resource[:install_options].collect do |k,v|
+      if k == 'registry'
+        extraopts += [ "--registry" , v ]
       end
     end
 

--- a/lib/puppet/provider/package/npm.rb
+++ b/lib/puppet/provider/package/npm.rb
@@ -72,7 +72,7 @@ Puppet::Type.type(:package).provide :npm, :parent => Puppet::Provider::Package d
 
     extraopts = []
 
-    extraopts += resource[:install_options].collect do |k,v|
+    extraopts += resource.fetch(:install_options,{}).collect do |k,v|
       if k == 'registry'
         extraopts += [ "--registry" , v ]
       end

--- a/lib/puppet/provider/package/npm.rb
+++ b/lib/puppet/provider/package/npm.rb
@@ -72,6 +72,14 @@ Puppet::Type.type(:package).provide :npm, :parent => Puppet::Provider::Package d
 
     extraopts = nil
 
+    if resource[:install_options]
+      resource[:install_options].collect do |k,v|
+        if k == 'registry'
+          extraopts = "--registry #{v}"
+        end
+      end
+    end
+
     if resource[:source]
       npm('install', '--global', resource[:source])
     else

--- a/lib/puppet/provider/package/npm.rb
+++ b/lib/puppet/provider/package/npm.rb
@@ -72,9 +72,11 @@ Puppet::Type.type(:package).provide :npm, :parent => Puppet::Provider::Package d
 
     extraopts = []
 
-    extraopts += resource.fetch(:install_options,{}).collect do |k,v|
-      if k == 'registry'
-        extraopts += [ "--registry" , v ]
+    if resource[:install_options]
+      extraopts += resource[:install_options].collect do |k,v|
+        if k == 'registry'
+          extraopts += [ "--registry" , v ]
+        end
       end
     end
 

--- a/spec/unit/puppet/provider/pakages/npm_spec.rb
+++ b/spec/unit/puppet/provider/pakages/npm_spec.rb
@@ -30,7 +30,7 @@ describe Puppet::Type.type(:package).provider(:npm) do
 
     describe "and install options are specified" do
       it "should use the given registry" do
-        @resource[:source] = {'registry'=>'http://custom.registry/npm'}
+        @resource[:install_options] = {'registry'=>'http://custom.registry/npm'}
         @provider.expects(:npm).with('install', '--global', '--registry', 'http://custom.registry/npm', 'express')
         @provider.install
       end


### PR DESCRIPTION
Add install_options feature to enable the use of a custom registry. This avoids changes on .npmrc, and can be used on a per-package basis.