### PR TITLE
Ensure as first attribute

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -90,8 +90,8 @@ class nodejs(
   anchor { 'nodejs::repo': }
 
   package { 'nodejs':
-    name    => $nodejs::params::node_pkg,
     ensure  => $version,
+    name    => $nodejs::params::node_pkg,
     require => Anchor['nodejs::repo']
   }
 
@@ -114,8 +114,8 @@ class nodejs(
 
     default: {
       package { 'npm':
-        name    => $nodejs::params::npm_pkg,
         ensure  => present,
+        name    => $nodejs::params::npm_pkg,
         require => Anchor['nodejs::repo']
       }
     }
@@ -131,8 +131,8 @@ class nodejs(
 
   if $dev_package and $nodejs::params::dev_pkg {
     package { 'nodejs-dev':
-      name    => $nodejs::params::dev_pkg,
       ensure  => $version,
+      name    => $nodejs::params::dev_pkg,
       require => Anchor['nodejs::repo']
     }
   }


### PR DESCRIPTION
linting fixes:
modules/nodejs/manifests/init.pp - WARNING: ensure found on line but it's not the first attribute on line 94
modules/nodejs/manifests/init.pp - WARNING: ensure found on line but it's not the first attribute on line 118
modules/nodejs/manifests/init.pp - WARNING: ensure found on line but it's not the first attribute on line 135