### PR TITLE
fixes for npm config proxy

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,7 +11,7 @@
 class nodejs(
   $dev_package = false,
   $manage_repo = false,
-  $proxy       = '',
+  $proxy       = undef,
   $version     = 'present'
 ) inherits nodejs::params {
   #input validation

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -103,6 +103,7 @@ class nodejs(
     'Ubuntu': {
       # The PPA we are using on Ubuntu includes NPM in the nodejs package, hence
       # we must not install it separately
+      $npm_require = Package['nodejs']
     }
 
     'Gentoo': {
@@ -114,10 +115,12 @@ class nodejs(
         use     => 'npm',
         require => Anchor['nodejs::repo'],
       }
+      $npm_require = [$nodejs::params::node_pkg]
     }
 
     'Archlinux': {
       # Archlinux installes npm with the nodejs package.
+      $npm_require = Package['nodejs']
     }
 
     default: {
@@ -126,6 +129,7 @@ class nodejs(
         ensure  => present,
         require => Anchor['nodejs::repo']
       }
+      $npm_require = Package['npm']
     }
   }
 
@@ -133,7 +137,7 @@ class nodejs(
     exec { 'npm_proxy':
       command => "npm config set proxy ${proxy}",
       path    => $::path,
-      require => Package['npm'],
+      require => $npm_require
     }
   }
 

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -222,7 +222,7 @@ describe 'nodejs', :type => :class do
     it { should_not contain_package('npm') }
     it { should contain_exec('npm_proxy').with({
       'command' => 'npm config set proxy http://proxy.puppetlabs.lan:80/',
-      'require' => 'Package[npm]',
+      'require' => 'Package[nodejs]',
     }) }
     it { should_not contain_package('nodejs-stable-release') }
   end


### PR DESCRIPTION
- ensure noop when proxy is default (undef instead of empty string)
- fix the require package to be compatible with all OSes