### PR TITLE
Don't install nodejs-dev for Ubuntu dev repo

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -137,7 +137,9 @@ class nodejs(
     }
   }
 
-  if $dev_package and $nodejs::params::dev_pkg {
+  # Chris Lea's dev repos for Ubuntu do not include the nodejs-dev package,
+  # it was merged into the nodejs package.
+  if $dev_package and $nodejs::params::dev_pkg and !($::operatingsystem == 'Ubuntu' and $manage_repo) {
     package { 'nodejs-dev':
       name    => $nodejs::params::dev_pkg,
       ensure  => $version,

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -72,13 +72,17 @@ describe 'nodejs', :type => :class do
     context 'when manage_repo is true' do
       it { should contain_class('apt') }
       it { should contain_apt__ppa('ppa:chris-lea/node.js') }
+      it { should_not contain_package('nodejs-dev') }
     end
     context 'when manage_repo is false' do
-      it 'should not create the ppa' do
+      before :each do
         params.merge!({:manage_repo => false})
+      end
+      it 'should not create the ppa' do
         should_not contain_class('apt')
         should_not contain_apt__ppa('ppa:chris-lea/node.js')
       end
+      it { should contain_package('nodejs-dev') }
     end
 
     it { should contain_class('apt') }
@@ -89,7 +93,6 @@ describe 'nodejs', :type => :class do
       'name'    => 'nodejs',
       'require' => 'Anchor[nodejs::repo]',
     }) }
-    it { should contain_package('nodejs-dev') }
     it { should_not contain_package('npm') }
     it { should_not contain_package('nodejs-stable-release') }
   end


### PR DESCRIPTION
The nodejs-dev package is now included as part of the nodejs package in
Chris Lea's node.js-devel repository for Ubuntu.

This stops attempting to install the node-dev package when using that
repo.