### PR TITLE
Add max_nesting parameter to npm list json parse

### DIFF
--- a/lib/puppet/provider/package/npm.rb
+++ b/lib/puppet/provider/package/npm.rb
@@ -20,7 +20,7 @@ Puppet::Type.type(:package).provide :npm, :parent => Puppet::Provider::Package d
     Puppet.debug("Warning: npm list --json exited with code #{$CHILD_STATUS.exitstatus}") unless $CHILD_STATUS.success?
     begin
       # ignore any npm output lines to be a bit more robust
-      output = PSON.parse(output.lines.select{ |l| l =~ /^((?!^npm).*)$/}.join("\n"))
+      output = PSON.parse(output.lines.select{ |l| l =~ /^((?!^npm).*)$/}.join("\n"), {:max_nesting => 100} )
       @npmlist = output['dependencies'] || {}
     rescue PSON::ParserError => e
       Puppet.debug("Error: npm list --json command error #{e.message}")


### PR DESCRIPTION
Json parsing faild due to too deep nesting, and this made the install check fail. This caused the packages to be reinstalled  on each run.

Hard coded to 100

==> default: Debug: Executing '/usr/bin/npm list --json --global'
==> default: Debug: Error: npm list --json command error nesting of 20 is too deep
==> default: Debug: Executing '/usr/bin/npm install --global bower'