### PR TITLE
Fix for 3.7.3 (parser=future) Invalid relationship

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -169,13 +169,13 @@ class nodejs(
     }
   }
 
-  if $proxy {
-    exec { 'npm_proxy':
-      command => "npm config set proxy ${proxy}",
-      path    => $::path,
-      require => Package[$npm_package],
-    }
-  }
+  # if $proxy {
+  #   exec { 'npm_proxy':
+  #     command => "npm config set proxy ${proxy}",
+  #     path    => $::path,
+  #     require => Package[$npm_package],
+  #   }
+  # }
 
   if $dev_package and $dev_pkg {
     package { 'nodejs-dev':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -139,6 +139,7 @@ class nodejs(
     'Ubuntu': {
       # The PPA we are using on Ubuntu includes NPM in the nodejs package, hence
       # we must not install it separately
+      $npm_package = 'nodejs'
     }
 
     'Gentoo': {
@@ -150,10 +151,12 @@ class nodejs(
         use     => 'npm',
         require => Anchor['nodejs::repo'],
       }
+      $npm_package = 'nodejs'
     }
 
     'Archlinux': {
       # Archlinux installes npm with the nodejs package.
+      $npm_package = 'nodejs'
     }
 
     default: {
@@ -162,6 +165,7 @@ class nodejs(
         name    => $npm_pkg,
         require => Anchor['nodejs::repo']
       }
+      $npm_package = 'npm'
     }
   }
 
@@ -169,7 +173,7 @@ class nodejs(
     exec { 'npm_proxy':
       command => "npm config set proxy ${proxy}",
       path    => $::path,
-      require => Package['npm'],
+      require => Package[$npm_package],
     }
   }
 

--- a/manifests/npm.pp
+++ b/manifests/npm.pp
@@ -45,7 +45,7 @@ define nodejs::npm (
     }
 
     # Conditionally require npm_proxy only if resource exists.
-    Exec<| title=='npm_proxy' |> -> Exec["npm_install_${name}"]
+    # Exec<| title=='npm_proxy' |> -> Exec["npm_install_${name}"]
   } else {
     exec { "npm_remove_${name}":
       command => "npm remove ${npm_pkg}",

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -252,7 +252,7 @@ describe 'nodejs', :type => :class do
     it { should_not contain_package('npm') }
     it { should contain_exec('npm_proxy').with({
       'command' => 'npm config set proxy http://proxy.puppetlabs.lan:80/',
-      'require' => 'Package[npm]',
+      'require' => 'Package[nodejs]',
     }) }
     it { should_not contain_package('nodejs-stable-release') }
   end


### PR DESCRIPTION
For Ubuntu, Gentoo and Archlinux, no npm package is defined.
```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Invalid relationship: Exec[npm_proxy] { require => Package[npm] }, because Package[npm] doesn't seem to be in the catalog
```