### PR TITLE
added support for installing latest nodejs for Enterprise Linux from nod...

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,6 +44,7 @@ class nodejs::params {
       $npm_pkg  = 'npm'
       $dev_pkg  = 'nodejs-devel'
       $baseurl  = 'http://patches.fedorapeople.org/oldnode/stable/el$releasever/$basearch/'
+      $gpgkey   = 'http://patches.fedorapeople.org/oldnode/stable/RPM-GPG-KEY-tchol'
     }
 
     'Fedora': {
@@ -52,6 +53,7 @@ class nodejs::params {
       $dev_pkg  = 'nodejs-devel'
       $gpgcheck = 1
       $baseurl  = 'http://patches.fedorapeople.org/oldnode/stable/f$releasever/$basearch/'
+      $gpgkey   = 'http://patches.fedorapeople.org/oldnode/stable/RPM-GPG-KEY-tchol'
     }
 
     'Amazon': {


### PR DESCRIPTION
I needed to install the latest nodejs as the fedora repository is quite old.  I added boolean parameter to use nodesource.com repository for Enterprise Linux, added nodesource repository.  also added conditional around package npm install as npm is part of nodejs package from nodesource.