### PR TITLE
Make it obvious NodeSource doesn't have a npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,12 @@ and configures global npm configuration settings. A defined type nodejs::npm
 is used for the local installation of npm packages.
 
 By default this module installs packages from the [NodeSource](https://nodesource.com)
-repository on Debian and RedHat platforms. On SUSE, ArchLinux, FreeBSD, OpenBSD
-and Gentoo, native packages are used. On Darwin, the MacPorts package is used.
-On Windows the packages are installed via Chocolatey.
+repository on Debian and RedHat platforms. The NodeSource Node.js package
+includes the npm binary, which makes a separate npm package unnecessary.
+
+On SUSE, ArchLinux, FreeBSD, OpenBSD and Gentoo, native packages are used. On
+Darwin, the MacPorts package is used. On Windows the packages are installed
+via Chocolatey.
 
 ## Setup
 


### PR DESCRIPTION
I am sorry for the 'negates the need' phrase, but I was out of words at the time.