### PR TITLE
Update apt.pp

### DIFF
--- a/manifests/repo/nodesource/apt.pp
+++ b/manifests/repo/nodesource/apt.pp
@@ -10,7 +10,7 @@ class nodejs::repo::nodesource::apt {
   if ($ensure == 'present') {
     apt::source { 'nodesource':
       include_src       => $enable_src,
-      key               => '1655A0AB68576280',
+      key               => '68576280',
       key_source        => 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key',
       location          => 'https://deb.nodesource.com/node',
       pin               => $pin,


### PR DESCRIPTION
I was testing in my lab, and i'm always getting this line:

Notice: /Stage[main]/Nodejs::Repo::Nodesource::Apt/Apt::Source[nodesource]/Apt::Repository[nodesource]/Apt::Key[1655A0AB68576280]/Exec[aptkey_add_1655A0AB68576280]/returns: executed successfully

So, i saw that https://github.com/puppetlabs/puppetlabs-nodejs/blob/master/manifests/repo/nodesource/apt.pp#L14 

that you've sent key_url, so repo fingerprint will not be used the way you want : 
https://github.com/example42/puppet-apt/blob/master/manifests/key.pp#L47

This returns nothing:
apt-key list | grep  1655A0AB68576280 

But this : 

apt-key list | grep  68576280
pub   4096R/68576280 2014-06-13

 