### PR TITLE
Fix class containment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ##2015-02-27 0.8.0
 ###Backwards-incompatible changes
+- Puppet versions below 3.4.0 are no longer supported
 - Debian Squeeze and Fedora version 18 and below are explicitly no longer
   supported
 - Parameter naming changes to node_pkg, npm_pkg, dev_pkg, manage_repo,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,14 +47,11 @@ class nodejs(
 
   include '::nodejs::install'
 
-  anchor { '::nodejs::begin': }
-  anchor { '::nodejs::end': }
-
   if $manage_package_repo {
     include $repo_class
-    Anchor['::nodejs::begin'] ->
+    anchor { '::nodejs::begin': } ->
     Class[$repo_class] ->
     Class['::nodejs::install'] ->
-    Anchor['::nodejs::end']
+    anchor { '::nodejs::end': }
   }
 }

--- a/manifests/repo/nodesource.pp
+++ b/manifests/repo/nodesource.pp
@@ -12,7 +12,7 @@ class nodejs::repo::nodesource {
   case $::osfamily {
     'RedHat': {
       if $::operatingsystemrelease =~ /^5\.(\d+)/ {
-        include '::epel'
+        include ::epel
         $dist_version  = '5'
         $name_string   = 'Enterprise Linux 5'
       }
@@ -51,6 +51,13 @@ class nodejs::repo::nodesource {
       $source_baseurl = "https://rpm.nodesource.com/pub/${dist_type}/${dist_version}/SRPMS"
 
       class { '::nodejs::repo::nodesource::yum': }
+      contain '::nodejs::repo::nodesource::yum'
+
+      if $::operatingsystemrelease =~ /^5\.(\d+)/ {
+        # On EL 5, EPEL needs to be applied first
+        Class['::epel'] -> Class['::nodejs::repo::nodesource::yum']
+      }
+
     }
     'Linux': {
       if $::operatingsystem == 'Amazon' {
@@ -76,6 +83,7 @@ class nodejs::repo::nodesource {
         $source_baseurl = "https://rpm.nodesource.com/pub/${dist_type}/${dist_version}/SRPMS"
 
         class { '::nodejs::repo::nodesource::yum': }
+        contain '::nodejs::repo::nodesource::yum'
       }
 
       else {
@@ -85,7 +93,8 @@ class nodejs::repo::nodesource {
       }
     }
     'Debian': {
-      class { 'nodejs::repo::nodesource::apt': }
+      class { '::nodejs::repo::nodesource::apt': }
+      contain '::nodejs::repo::nodesource::apt'
     }
     default: {
       if ($ensure == 'present') {


### PR DESCRIPTION
The `nodejs::repo::nodesource` class includes a few classes that are not contained properly, meaning for instance that the NodeSource repository might be created after the Node.js package is installed when the distribution comes with a native Node.js package. This PR is an attempt to fix this without using inheritance, making some anchor readability changes as well. Failing RSpec test should already be fixed in #120 .