### PR TITLE
Update apt key to full 40characters

### DIFF
--- a/manifests/repo/nodesource/apt.pp
+++ b/manifests/repo/nodesource/apt.pp
@@ -10,7 +10,7 @@ class nodejs::repo::nodesource::apt {
   if ($ensure == 'present') {
     apt::source { 'nodesource':
       include_src       => $enable_src,
-      key               => '1655A0AB68576280',
+      key               => '9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280',
       key_source        => 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key',
       location          => 'https://deb.nodesource.com/node',
       pin               => $pin,


### PR DESCRIPTION
Latest version of puppetlabs/apt module shows warning on every puppet run if using a short key so this update includes the full 40 character key.