### PR TITLE
Update rspec-puppet tests for 2.0

### DIFF
--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -11,7 +11,7 @@ describe 'nodejs', :type => :class do
     end
 
     it 'should fail' do
-      expect { subject }.to raise_error(Puppet::Error, /The nodejs module is not supported on Debian Squeeze./)
+      expect { catalogue }.to raise_error(Puppet::Error, /The nodejs module is not supported on Debian Squeeze./)
     end
   end
 
@@ -305,8 +305,8 @@ describe 'nodejs', :type => :class do
       }
     end
 
-    it 'should fail' do
-      expect { subject }.to raise_error(Puppet::Error, /The nodejs module is not supported on Fedora 18./)
+    it do
+      expect { catalogue }.to raise_error(Puppet::Error, /The nodejs module is not supported on Fedora 18./)
     end
   end
 

--- a/spec/defines/global_config_entry_spec.rb
+++ b/spec/defines/global_config_entry_spec.rb
@@ -56,9 +56,7 @@ describe 'nodejs::npm::global_config_entry', :type => :define do
       let (:params) { { :ensure => 'invalid_value' } }
 
       it 'should fail' do
-        expect {
-          should raise_error(Puppet::Error, /nodejs::npm::global_config_entry : Ensure parameter must be present or absent/)
-        }
+        expect { catalogue }.to raise_error(Puppet::Error, /nodejs::npm::global_config_entry : Ensure parameter must be present or absent/)
       end
     end
   end

--- a/spec/defines/nodejs_npm_spec.rb
+++ b/spec/defines/nodejs_npm_spec.rb
@@ -360,7 +360,7 @@ describe 'nodejs::npm', :type => :define do
       }}
   
       it 'should fail' do
-        expect { subject }.to raise_error(Puppet::Error, /The nodejs::npm defined type does not accept version ranges/)
+        expect { catalogue }.to raise_error(Puppet::Error, /The nodejs::npm defined type does not accept version ranges/)
       end
     end
 


### PR DESCRIPTION
Replace `subject` with `catalogue` for the raise_error matchers