### PR TITLE
Handle NodeSource Debian URL suffixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,16 @@ On Windows the packages are installed via Chocolatey.
 To install Node.js and npm (using the NodeSource repository if possible):
 
 ```puppet
-    class { 'nodejs': }
+class { 'nodejs': }
+```
+
+If you wish to install a Node.js 0.12.x release from the NodeSource repository
+rather than 0.10.x on Debian platforms:
+
+```puppet
+class { 'nodejs':
+  repo_url_suffix => 'node_0.12',
+}
 ```
 
 ## Usage
@@ -392,6 +401,12 @@ Password for the proxy used by the repository, if required.
 #### `repo_proxy_username`
 
 User for the proxy used by the repository, if required.
+
+#### `repo_url_suffix`
+
+This module defaults to installing the latest NodeSource 0.10.x release on
+Debian platforms. If you wish to install a 0.12.x release you will need to
+set this parameter to `node_0.12` instead.
 
 #### `use_flags`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,7 @@ class nodejs(
   $repo_proxy                  = $nodejs::params::repo_proxy,
   $repo_proxy_password         = $nodejs::params::repo_proxy_password,
   $repo_proxy_username         = $nodejs::params::repo_proxy_username,
+  $repo_url_suffix             = $nodejs::params::repo_url_suffix,
   $use_flags                   = $nodejs::params::use_flags,
 ) inherits nodejs::params {
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,6 +10,7 @@ class nodejs::params {
   $repo_proxy                  = 'absent'
   $repo_proxy_password         = 'absent'
   $repo_proxy_username         = 'absent'
+  $repo_url_suffix             = 'node_0.10'
   $use_flags                   = ['npm', 'snapshot']
 
   # The full path to cmd.exe is required on Windows. The system32 fact is only

--- a/manifests/repo/nodesource.pp
+++ b/manifests/repo/nodesource.pp
@@ -7,6 +7,7 @@ class nodejs::repo::nodesource {
   $proxy          = $nodejs::repo_proxy
   $proxy_password = $nodejs::repo_proxy_password
   $proxy_username = $nodejs::repo_proxy_username
+  $url_suffix     = $nodejs::repo_url_suffix
 
   case $::osfamily {
     'RedHat': {

--- a/manifests/repo/nodesource/apt.pp
+++ b/manifests/repo/nodesource/apt.pp
@@ -4,6 +4,7 @@ class nodejs::repo::nodesource::apt {
   $enable_src = $nodejs::repo::nodesource::enable_src
   $ensure     = $nodejs::repo::nodesource::ensure
   $pin        = $nodejs::repo::nodesource::pin
+  $url_suffix = $nodejs::repo::nodesource::url_suffix
 
   include ::apt
 
@@ -12,7 +13,7 @@ class nodejs::repo::nodesource::apt {
       include_src       => $enable_src,
       key               => '1655A0AB68576280',
       key_source        => 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key',
-      location          => 'https://deb.nodesource.com/node',
+      location          => "https://deb.nodesource.com/${url_suffix}",
       pin               => $pin,
       release           => $::lsbdistcodename,
       repos             => 'main',

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -148,6 +148,20 @@ describe 'nodejs', :type => :class do
           end
         end
 
+        context 'and repo_url_suffix set to node_0.12' do
+          let :params do
+            default_params.merge!({
+              :repo_url_suffix => 'node_0.12',
+            })
+          end
+
+          it 'the repo apt::source resource should contain location = https://deb.nodesource.com/node_0.12' do
+            should contain_apt__source('nodesource').with({
+              'location' => 'https://deb.nodesource.com/node_0.12'
+            })
+          end
+        end
+
         context 'and repo_ensure set to present' do
           let :params do
             default_params.merge!({

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -11,7 +11,7 @@ describe 'nodejs', :type => :class do
     end
 
     it 'should fail' do
-      expect { subject }.to raise_error(Puppet::Error, /The nodejs module is not supported on Debian Squeeze./)
+      expect { catalogue }.to raise_error(Puppet::Error, /The nodejs module is not supported on Debian Squeeze./)
     end
   end
 
@@ -305,8 +305,8 @@ describe 'nodejs', :type => :class do
       }
     end
 
-    it 'should fail' do
-      expect { subject }.to raise_error(Puppet::Error, /The nodejs module is not supported on Fedora 18./)
+    it do
+      expect { catalogue }.to raise_error(Puppet::Error, /The nodejs module is not supported on Fedora 18./)
     end
   end
 

--- a/spec/defines/global_config_entry_spec.rb
+++ b/spec/defines/global_config_entry_spec.rb
@@ -56,9 +56,7 @@ describe 'nodejs::npm::global_config_entry', :type => :define do
       let (:params) { { :ensure => 'invalid_value' } }
 
       it 'should fail' do
-        expect {
-          should raise_error(Puppet::Error, /nodejs::npm::global_config_entry : Ensure parameter must be present or absent/)
-        }
+        expect { catalogue }.to raise_error(Puppet::Error, /nodejs::npm::global_config_entry : Ensure parameter must be present or absent/)
       end
     end
   end

--- a/spec/defines/nodejs_npm_spec.rb
+++ b/spec/defines/nodejs_npm_spec.rb
@@ -360,7 +360,7 @@ describe 'nodejs::npm', :type => :define do
       }}
   
       it 'should fail' do
-        expect { subject }.to raise_error(Puppet::Error, /The nodejs::npm defined type does not accept version ranges/)
+        expect { catalogue }.to raise_error(Puppet::Error, /The nodejs::npm defined type does not accept version ranges/)
       end
     end
 


### PR DESCRIPTION
Based on PR #118 but adds RSpec tests and allows those who want bleeding fingers to install io.js with:

```puppet
class { '::nodejs':
  package_name => 'iojs',
  repo_url_suffix => 'iojs_1.x',
}
```

This PR still defaults to using Node.js 0.10.x as the latest version on Debian platforms rather than 0.12.x for the moment. (Note that NodeSource does not host a 0.12.x version for Lucid)