### PR TITLE
Document that puppetlabs-apt versions less than 2.x are required

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,9 @@
 fixtures:
   repositories:
     "stdlib": "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-    "apt": "git://github.com/puppetlabs/puppetlabs-apt.git"
+    "apt":
+      repo: "git://github.com/puppetlabs/puppetlabs-apt.git"
+      ref: "1.8.0"
     "portage": "git://github.com/gentoo/puppet-portage.git"
     "chocolatey": "git://github.com/rismoney/puppet-chocolatey.git"
     "epel": "git://github.com/stahnma/puppet-module-epel.git"

--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ it is installed.
 
 This modules uses `puppetlabs-apt` for the management of the NodeSource
 repository. If using an operating system of the Debian-based family, you will
-need to ensure that it is installed.
+need to ensure that `puppetlabs-apt` version 1.x is installed.
 
 If using CentoOS/RHEL 5, you will need to ensure that the `stahnma-epel`
 module is installed.


### PR DESCRIPTION
puppetlabs-apt 2.x changes apt::source parameters substantially. This patch makes it clear that this module will break if puppetlabs-apt 2.x is used currently.

The idea is that this module targets puppetlabs-apt 1.x up to the next tagged release (0.8.x), then this module gets modified to target puppetlabs-apt 2.x-only after this point (eg. puppetlabs-nodejs 0.9.x targets puppetlabs-apt 2.x)